### PR TITLE
Fixed URL opener and optimised install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,24 +21,28 @@ fi
 # Install python if it is not already.
 if ! apt-cache pkgnames | grep "^python$" &>/dev/null; then
   printf '\e[0;36mInstalling python\e[0m\n'
+  sleep 2
   apt-get install python -y
 fi
 
 # Install the youtube-dl python module if it isnt installed.
 if ! pip list | grep "^youtube-dl" &>/dev/null; then
   printf '\e[0;36mInstalling youtube-dl\e[0m\n'
+  sleep 2
   pip install youtube-dl
 fi
 
 # Create the output directory if needed.
 if [ ! -d "${TERMUX_HOME}/storage/shared/Youtube" ]; then
   printf '\e[0;36mCreating output directory at "~/storage/shared/Youtube"\e[0m\n'
+  sleep 2
   mkdir "${TERMUX_HOME}/storage/shared/Youtube"
 fi
 
 # Create the directory for our config file.
 if [ ! -d "${TERMUX_HOME}/.config/youtube-dl" ]; then
   printf '\e[0;36mCreating config directory for youtube-dl\e[0m\n'
+  sleep 2
   mkdir -p "${TERMUX_HOME}/.config/youtube-dl"
 fi
 
@@ -47,6 +51,7 @@ printf '\e[0;36mInstalling Termux-YTD\e[0m\n'
 mkdir -p "${TERMUX_HOME}/bin"
 mv termux-url-opener "${TERMUX_HOME}/bin"
 chmod +x "${TERMUX_HOME}/bin/termux-url-opener"
+sleep 2
 
 printf '\n\e[0;36mInstallation Complete!\e[0m\n'
 printf '\e[0;36mJust open the video you want to download in youtube, click share, select termux, choose a quality, and the download will start\e[0m\n'

--- a/install.sh
+++ b/install.sh
@@ -5,40 +5,49 @@
 # Github: https://github.com/khansaad1275/Termux-YTD
 # Date : 14/4/2020
 
-#Probably make a varible with the file name 
-#make it more easy to update!
-echo -e "\e[035m"  "Updating default packages\n"
-apt update && apt upgrade -y
+TERMUX_HOME="/data/data/com.termux/files/home"
 
-echo -e "\e[032m" "Requesting acces to storage\n"
-sleep 2
-echo -e "\e[032m" "Allow Storage Permission!"
-sleep 2
-termux-setup-storage 
-sleep 5
+# Make sure we are up to date.
+printf '\e[01;36mRetriving package lists and updating\e[0m\n'
+apt-get update && apt-get upgrade -y
 
-#echo -e "\e[033m" "Installing python\n"
-pkg install python -y
+# If the storage directory does not exist run termux-setup-storage.
+if [ ! -d "${TERMUX_HOME}/storage" ]; then
+  printf '\e[0;36mRequesting acces to storage\e[0m\n'
+  sleep 2
+  termux-setup-storage
+fi
 
-echo -e "\e[034m"  "Installing youtube-dl\n"
-pip install youtube-dl
+# Install python if it is not already.
+if ! apt-cache pkgnames | grep "^python$" &>/dev/null; then
+  printf '\e[0;36mInstalling python\e[0m\n'
+  apt-get install python -y
+fi
 
-echo -e "\e[032m"  "Making the Youtube Directory to download the Vidoes\n"
-mkdir ~/storage/shared/Youtube
+# Install the youtube-dl python module if it isnt installed.
+if ! pip list | grep "^youtube-dl" &>/dev/null; then
+  printf '\e[0;36mInstalling youtube-dl\e[0m\n'
+  pip install youtube-dl
+fi
 
-echo -e "\e[036m"  "Creating youtube-dl folder for config\n"
-mkdir -p ~/.config/youtube-dl
+# Create the output directory if needed.
+if [ ! -d "${TERMUX_HOME}/storage/shared/Youtube" ]; then
+  printf '\e[0;36mCreating output directory at "~/storage/shared/Youtube"\e[0m\n'
+  mkdir "${TERMUX_HOME}/storage/shared/Youtube"
+fi
 
-echo -e "Creating bin folder\n"
-mkdir ~/bin
+# Create the directory for our config file.
+if [ ! -d "${TERMUX_HOME}/.config/youtube-dl" ]; then
+  printf '\e[0;36mCreating config directory for youtube-dl\e[0m\n'
+  mkdir -p "${TERMUX_HOME}/.config/youtube-dl"
+fi
 
-echo -e "Creating Termux-URL-Opener Script.\n"
+# Install the url opener.
+printf '\e[0;36mInstalling Termux-YTD\e[0m\n'
+mkdir -p "${TERMUX_HOME}/bin"
+mv termux-url-opener "${TERMUX_HOME}/bin"
+chmod +x "${TERMUX_HOME}/bin/termux-url-opener"
 
-mv termux-url-opener ~/bin/
-#Oh hey Don't forget to chmod that file there!
-
-#chmod +x ~/bin/termux-url-opener
-echo -e "\n"
-echo -e "\e[032m" "Process Complete!"
-echo -e "\e[032m" "Now you can share any Youtube video with Termux and you will be ask to select the quality of your downloaded video and after that,It will be automatically Downloaded"
-echo -e "\e[033m" "For More Awesome and Useful Tool like this Visit My website ©www.LearnTermux.tech"
+printf '\n\e[0;36mInstallation Complete!\e[0m\n'
+printf '\e[0;36mJust open the video you want to download in youtube, click share, select termux, choose a quality, and the download will start\e[0m\n'
+printf '\e[0;32mFor More Awesome and Useful Tool like this Visit My website ©www.LearnTermux.tech\e[0m\n'

--- a/termux-url-opener
+++ b/termux-url-opener
@@ -23,7 +23,7 @@ echo -e "\e[032m" "╠═▶ 4. Video 720p"
 echo -e "\e[032m" "╠═▶ 5. Video 1080p"
 echo -e "\e[032m" "╠═▶ 6. Video 2160p"
 echo -e "\e[032m" "╠═▶ 7. Exit Termux-YTD" # Added
-command='-no-mtime -o /data/data/com.termux/files/home/storage/shared/Youtube/%(title)s.%(ext)s -f'
+command='-no-mtime -o /data/data/com.termux/files/home/storage/shared/Youtube/%(title)s.%(ext)s -i -f'
 
 #Edit From Oak Atsume 
 printf "\e[032m ╚═:➤  $kill_color"
@@ -40,23 +40,23 @@ case $option in #Make Case list
 	youtube-dl $1
 	;;
 	2)
-	echo "$command -i \"best[height<=360]\"" > ~/.config/youtube-dl/config #option 2
+	echo "$command \"best[height<=360]\"" > ~/.config/youtube-dl/config #option 2
 	youtube-dl $1
 	;;
 	3)
-	echo "$command -i \"best[height<=480]\"" > ~/.config/youtube-dl/config #option 3
+	echo "$command \"best[height<=480]\"" > ~/.config/youtube-dl/config #option 3
 	youtube-dl $1
 	;;
 	4)
-	echo "$command -i \"best[height<=720]\"" > ~/.config/youtube-dl/config #option 4
+	echo "$command \"best[height<=720]\"" > ~/.config/youtube-dl/config #option 4
 	youtube-dl $1
 	;;
 	5)
-	echo "$command -i \"best[height<=1080]\"" > ~/.config/youtube-dl/config #option 5
+	echo "$command \"best[height<=1080]\"" > ~/.config/youtube-dl/config #option 5
 	youtube-dl $1
 	;;
 	6)
-	echo "$command -i \"best[height<=2160]\"" > ~/.config/youtube-dl/config
+	echo "$command \"best[height<=2160]\"" > ~/.config/youtube-dl/config
     	youtube-dl $1
 	;;
 	7)


### PR DESCRIPTION
Changes made:
1. Fixed `termux-url-opener` by reordering arguments.
2. Replaced usage of `echo -e` with `printf` as `echo` flags are undefined in POSIX sh.
3. Use `apt-get` in place of `apt` for better stability within the script.
4. Added checks so no unnecessary steps are taken.